### PR TITLE
fix(#28): remove debug settings in Actions yml and Dockerfile.

### DIFF
--- a/.github/workflows/twittervotes-cicd-actions.yml
+++ b/.github/workflows/twittervotes-cicd-actions.yml
@@ -20,9 +20,6 @@ jobs:
     - name: Build
       run: GOOS=linux CGO_ENABLED=0 go build -o twittervotes
 
-    - name: Debug
-      run: ls -al
-
     # バイナリーをartifactディレクトリにコピーする
     - name: Copy artifact
       run: mkdir -p artifact && cp twittervotes artifact/
@@ -40,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # 前のジョブで作成したバイナリーを取得
+    # 前のジョブで作成したバイナリーを取得（ディレクトリが作成され、その中にバイナリーが入るみたい）
     - uses: actions/download-artifact@v1
       with:
         name: twittervotes
@@ -48,9 +45,6 @@ jobs:
     # Goのビルドで生成したバイナリーに実行権限を追加
     - name: Add Permission to binary
       run: chmod +x twittervotes/twittervotes
-
-    - name: Debug
-      run: ls -al twittervotes/twittervotes
 
     # TODO：GitHubのコンテナレジストリにログイン
     - name: Login GitHub Registory

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,5 @@ ENV MONGO_HOST=twitter-votes-mongodb MONGO_PORT=27017 MONGO_DB=ballots MONGO_USE
 ENV NSQ_HOST=twitter-votes-nsqd NSQ_PORT=4150 NSQ_TOPIC=votes
 
 COPY twittervotes .
-RUN ls -al twittervotes
 
 ENTRYPOINT ["./twittervotes"]


### PR DESCRIPTION
以下のデバッグを削除
・`Dockerfile`の`ls`コマンド（実行ファイルの権限を確認のため）
・Actionsのyamlファイルのデバッグ処理（アーティファクトのディレクトリ階層やバイナリーの実行権限を確認のため）

close #28 